### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Code Quality


### PR DESCRIPTION
Potential fix for [https://github.com/razbuild/raztodo/security/code-scanning/5](https://github.com/razbuild/raztodo/security/code-scanning/5)

Add an explicit workflow-level `permissions` block granting only the minimum needed scope. For this workflow, `contents: read` is sufficient for `actions/checkout` and read-only CI tasks (lint/test). Place it near the top-level keys (after `on:` and before `jobs:`) so it applies to all jobs unless overridden.

Best single fix (without changing functionality):  
- Edit `.github/workflows/pr_test.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between the trigger section and `jobs:`.

No imports, methods, or extra definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
