### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/razbuild/raztodo/security/code-scanning/1](https://github.com/razbuild/raztodo/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/docker.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (checkout + local docker commands) while enforcing least privilege and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
