### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/razbuild/raztodo/security/code-scanning/4](https://github.com/razbuild/raztodo/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so it applies to both `lint` and `test` jobs. The minimal safe setting for this workflow is:

- `contents: read`

This preserves existing functionality (checkout and read access to repository content) while preventing unintended write permissions from default settings.  
Change location: `.github/workflows/ci.yml`, immediately after the `on:` trigger section (before `concurrency:` is a clean placement).  
No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
