### PR TITLE
Fix for Unused local variable

### DIFF
--- a/tests/infrastructure/sqlite/test_task_dao.py
+++ b/tests/infrastructure/sqlite/test_task_dao.py
@@ -85,7 +85,7 @@ class TestTaskDAO:
     def test_fetch_all_filter_done(self, dao):
         """Test filtering by done status."""
         task_id1 = dao.insert("Task 1")
-        _task_id2 = dao.insert("Task 2")
+        dao.insert("Task 2")
         dao.update(task_id1, done=True)
 
         done_rows = list(dao.fetch_all(done=True))


### PR DESCRIPTION
To fix this without changing functionality, keep the insert call for “Task 2” (so test setup remains identical) but remove the unused local variable assignment.

Best change:
- In `tests/infrastructure/sqlite/test_task_dao.py`, inside `test_fetch_all_filter_done`, replace:
  - `_task_id2 = dao.insert("Task 2")`
  with:
  - `dao.insert("Task 2")`

No imports, new methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._