### PR TITLE
Fix for Commented-out code

### DIFF
--- a/src/raztodo/presentation/cli/router.py
+++ b/src/raztodo/presentation/cli/router.py
@@ -107,9 +107,7 @@ class TaskRouter(HandlerProtocol):
     def get_usecase(self, name: str) -> Any:
         """Get use case instance for the given command name."""
 
-        # System commands don't need a usecase
-        # if command_name in self.SYSTEM_COMMANDS:
-        #     return None
+        # System commands don't need a usecase.
 
         uc_key = self.USECASE_MAP.get(name)
         if not uc_key:


### PR DESCRIPTION
Remove the commented-out code block in `get_usecase` and keep a normal explanatory comment only.

Best fix (no behavior change):
- In `src/raztodo/presentation/cli/router.py`, inside `get_usecase`, delete:
  - `# if command_name in self.SYSTEM_COMMANDS:`
  - `#     return None`
- Keep or slightly normalize the non-code comment (`# System commands don't need a usecase`) so intent remains documented.
- No imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._