### PR TITLE
Fix for Empty except

### DIFF
--- a/src/raztodo/application/use_cases/import_task.py
+++ b/src/raztodo/application/use_cases/import_task.py
@@ -74,6 +74,8 @@ class ImportTasksUseCase:
                         inserted += 1
                         continue
                 except RazTodoException:
+                    # In upsert mode, add_task may fail (for example, on duplicates);
+                    # fall through to search and update an existing task instead.
                     pass
 
                 matches: list[TaskEntity] = [


### PR DESCRIPTION
The best fix is to preserve existing upsert behavior while making the intentional exception swallowing explicit.  
In `src/raztodo/application/use_cases/import_task.py`, replace the `pass` inside `except RazTodoException:` with a short explanatory comment (and optionally `pass` can remain). This satisfies the rule’s requirement (“no explanatory comment”) and documents that add failures are expected in upsert mode (e.g., duplicate task), after which the code attempts to locate and update an existing task.

No new methods, imports, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._