### PR TITLE
Fix for Module is imported with 'import' and 'import from'

### DIFF
--- a/src/raztodo/infrastructure/sqlite/task_repository.py
+++ b/src/raztodo/infrastructure/sqlite/task_repository.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sqlite3
 from collections.abc import Callable
 from pathlib import Path
 from sqlite3 import Connection


### PR DESCRIPTION
Use a single import style for `sqlite3` in this file. The least invasive fix is to remove the redundant `import sqlite3` and keep `from sqlite3 import Connection`, since `Connection` is already used in type annotations in the shown code (`Callable[[], Connection]`, `_conn: Connection | None`).

**Change to make (file: `src/raztodo/infrastructure/sqlite/task_repository.py`):**
- Delete the line `import sqlite3`.
- Keep `from sqlite3 import Connection` unchanged.

No new methods, definitions, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._