### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/raztodo/presentation/cli/protocols.py
+++ b/src/raztodo/presentation/cli/protocols.py
@@ -3,7 +3,7 @@ from typing import Any, Protocol, runtime_checkable
 
 @runtime_checkable
 class Command(Protocol):
-    def __call__(self, *args: Any, **kwds: Any) -> int: ...
+    def __call__(self, *args: Any, **kwds: Any) -> int: pass
 
 
 class HandlerProtocol(Protocol):


### PR DESCRIPTION
To fix this without changing functionality, replace the `...` placeholder in the protocol method body with `pass`.  
In this file, only line 6 in `Command.__call__` needs editing.

- **General approach:** For protocol/abstract placeholder methods in `.py` files, prefer `pass` over bare `...` when static analysis flags no-effect statements.
- **Specific change:** In `src/raztodo/presentation/cli/protocols.py`, update:
  - `def __call__(self, *args: Any, **kwds: Any) -> int: ...`
  - to `def __call__(self, *args: Any, **kwds: Any) -> int: pass`
- **No imports/dependencies** are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._