### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/raztodo/presentation/cli/protocols.py
+++ b/src/raztodo/presentation/cli/protocols.py
@@ -12,3 +12,6 @@ class HandlerProtocol(Protocol):
 
     def get_usecase(self, name: str) -> Any:
         pass
+
+    def get_usecase(self, name: str) -> Any:
+        pass

--- a/src/raztodo/presentation/cli/protocols.py
+++ b/src/raztodo/presentation/cli/protocols.py
@@ -7,5 +7,8 @@ class Command(Protocol):
 
 
 class HandlerProtocol(Protocol):
-    def get_command_calss(self, name: str) -> type: ...
-    def get_usecase(self, name: str) -> Any: ...
+    def get_command_calss(self, name: str) -> type:
+        pass
+
+    def get_usecase(self, name: str) -> Any:
+        pass


### PR DESCRIPTION
To fix this cleanly, replace the ellipsis placeholder method bodies in the `HandlerProtocol` protocol with `pass`.  

Best fix (no functional change):
- File: `src/raztodo/presentation/cli/protocols.py`
- Region: `HandlerProtocol` methods (line 10 and similarly line 11 for consistency)
- Change:
  - `def get_command_calss(self, name: str) -> type: ...` → method block with `pass`
  - `def get_usecase(self, name: str) -> Any: ...` → method block with `pass`

No imports, new methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._