### PR TITLE
Fix for Statement has no effect

### DIFF
--- a/src/raztodo/application/use_case_factory.py
+++ b/src/raztodo/application/use_case_factory.py
@@ -7,16 +7,35 @@ from raztodo.domain.task_repository import TaskRepository
 class UseCaseFactory(Protocol):
     """Protocol for creating use case instances."""
 
-    def create_create_task(self, repo: TaskRepository) -> Any: ...
-    def create_delete_task(self, repo: TaskRepository) -> Any: ...
-    def create_list_tasks(self, repo: TaskRepository) -> Any: ...
-    def create_update_task(self, repo: TaskRepository) -> Any: ...
-    def create_search_tasks(self, repo: TaskRepository) -> Any: ...
-    def create_export_tasks(self, repo: TaskRepository) -> Any: ...
-    def create_import_tasks(self, repo: TaskRepository) -> Any: ...
-    def create_mark_done(self, repo: TaskRepository) -> Any: ...
-    def create_migrate(self, connection_factory: Callable[..., Any]) -> Any: ...
-    def create_clear_tasks(self, repo: TaskRepository) -> Any: ...
+    def create_create_task(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_delete_task(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_list_tasks(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_update_task(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_search_tasks(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_export_tasks(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_import_tasks(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_mark_done(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
+
+    def create_migrate(self, connection_factory: Callable[..., Any]) -> Any:
+        raise NotImplementedError
+
+    def create_clear_tasks(self, repo: TaskRepository) -> Any:
+        raise NotImplementedError
 
 
 class DefaultUseCaseFactory:


### PR DESCRIPTION
General fix approach: replace no-op stub statements (`...`) in protocol method bodies with a non-no-op statement that clearly indicates abstract intent, typically `raise NotImplementedError`.

Best single fix here: in `src/raztodo/application/use_case_factory.py`, update all `UseCaseFactory` protocol methods (lines 10–19) from one-line `...` stubs to explicit method blocks raising `NotImplementedError`. This preserves interface-only intent, avoids executable no-op statements, and satisfies CodeQL’s rule. No imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._