### PR TITLE
Fix for Unused local variable

### DIFF
--- a/tests/infrastructure/sqlite/test_task_repository.py
+++ b/tests/infrastructure/sqlite/test_task_repository.py
@@ -57,7 +57,7 @@ class TestSQLiteTaskRepository:
 
     def test_add_task_title_stripped(self, task_repo):
         """Test that title is stripped of whitespace."""
-        _task_id = task_repo.add_task("  Test Task  ")
+        task_repo.add_task("  Test Task  ")
         tasks = task_repo.get_tasks()
         assert len(tasks) == 1
         assert tasks[0].title == "Test Task"


### PR DESCRIPTION
General fix: remove unnecessary local variables that are assigned but never used, especially in tests, unless they are explicitly part of test intent.

Best fix here: in `tests/infrastructure/sqlite/test_task_repository.py`, inside `test_add_task_title_stripped`, replace the assignment to `_task_id` with a direct call to `task_repo.add_task(...)`. This preserves exact functionality (task creation still happens) while eliminating the unused variable warning.

No imports, helper methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._