### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/src/raztodo/presentation/cli/protocols.py
+++ b/src/raztodo/presentation/cli/protocols.py
@@ -12,6 +12,3 @@ class HandlerProtocol(Protocol):
 
     def get_usecase(self, name: str) -> Any:
         pass
-
-    def get_usecase(self, name: str) -> Any:
-        pass


### PR DESCRIPTION
Remove the duplicate `get_usecase` declaration from `HandlerProtocol` so the method is defined exactly once.

Best fix without changing functionality:
- Edit `src/raztodo/presentation/cli/protocols.py`.
- In `HandlerProtocol`, keep one `get_usecase(self, name: str) -> Any` method and delete the second duplicate block (lines 16–17 in the snippet).
- No import or dependency changes are needed.

This preserves intended protocol behavior while eliminating the redundant overwrite that CodeQL flagged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._