### PR TITLE
Fix for Unused local variable

### DIFF
--- a/tests/infrastructure/sqlite/test_task_repository.py
+++ b/tests/infrastructure/sqlite/test_task_repository.py
@@ -91,7 +91,7 @@ class TestSQLiteTaskRepository:
     def test_get_tasks_filter_done(self, task_repo):
         """Test filtering tasks by done status."""
         task_id1 = task_repo.add_task("Task 1")
-        _task_id2 = task_repo.add_task("Task 2")
+        task_repo.add_task("Task 2")
         task_repo.mark_done(task_id1, True)
 
         done_tasks = task_repo.get_tasks(done=True)


### PR DESCRIPTION
To fix this without changing functionality, keep the call that creates the second task but remove the unused local binding.

Best fix in this file/region:
- In `tests/infrastructure/sqlite/test_task_repository.py`, inside `test_get_tasks_filter_done`, replace:
  - `_task_id2 = task_repo.add_task("Task 2")`
- with:
  - `task_repo.add_task("Task 2")`

No imports, new methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._