### PR TITLE
Fix for Unused local variable

### DIFF
--- a/tests/infrastructure/sqlite/test_task_repository.py
+++ b/tests/infrastructure/sqlite/test_task_repository.py
@@ -244,7 +244,7 @@ class TestSQLiteTaskRepository:
 
     def test_priority_validation(self, task_repo):
         """Test that invalid priority is normalized."""
-        _task_id = task_repo.add_task("Task", priority="invalid")
+        task_repo.add_task("Task", priority="invalid")
         tasks = task_repo.get_tasks()
         assert tasks[0].priority == ""  # Invalid priority becomes empty
 


### PR DESCRIPTION
The best fix is to remove the unused local variable assignment and simply call the method for its side effect.  
In `tests/infrastructure/sqlite/test_task_repository.py`, inside `test_priority_validation`, replace:

- `_task_id = task_repo.add_task("Task", priority="invalid")`

with:

- `task_repo.add_task("Task", priority="invalid")`

No imports, helper methods, or additional definitions are needed. This keeps test behavior unchanged while eliminating the unused-variable warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._