### PR TITLE
Potential fix for code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/src/raztodo/presentation/web/routes/explain.py
+++ b/src/raztodo/presentation/web/routes/explain.py
@@ -28,8 +28,8 @@ def explain_task(
             for token in uc.stream(task_id, mode=mode):
                 safe = token.replace("\n", "\\n")
                 yield f"data: {safe}\n\n"
-        except RazTodoException as exc:
-            yield f"event: error\ndata: {exc}\n\n"
+        except RazTodoException as _exc:
+            yield "event: error\ndata: An internal error occurred.\n\n"
         finally:
             yield "data: [DONE]\n\n"
 


### PR DESCRIPTION
Potential fix for [https://github.com/razbuild/raztodo/security/code-scanning/10](https://github.com/razbuild/raztodo/security/code-scanning/10)

To fix this without changing endpoint behavior, keep SSE error signaling (`event: error`) but replace `data: {exc}` with a generic message that does not expose internal exception content.

Best change in this file:
- In `src/raztodo/presentation/web/routes/explain.py`, inside `_sse_generator`, update the `except RazTodoException as exc:` block so the yielded SSE error data is generic (for example, `"An internal error occurred."`).
- Since we won’t use `exc` anymore, rename it to `_exc` (or drop binding) to avoid lint warnings while preserving catch semantics.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
